### PR TITLE
Escaping identifiers

### DIFF
--- a/lib/css-selector-parser.js
+++ b/lib/css-selector-parser.js
@@ -64,7 +64,7 @@ CssSelectorParser.prototype.disableSubstitutes = function() {
 };
 
 function isIdentStart(c) {
-  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c === '-') || (c === '_');
 }
 
 function isIdent(c) {
@@ -113,24 +113,6 @@ var identSpecialChars = {
   '|': true,
   '}': true,
   '~': true
-};
-
-var identReplacements = {
-  'n': '\n',
-  'r': '\r',
-  't': '\t',
-  ' ': ' ',
-  'f': '\f',
-  'v': '\v'
-};
-
-var identReplacementsRev = {
-  '\n': '\\n',
-  '\r': '\\r',
-  '\t': '\\t',
-  ' ': '\\ ',
-  '\f': '\\f',
-  '\v': '\\v'
 };
 
 var strReplacementsRev = {
@@ -208,17 +190,17 @@ function ParseContext(str, pos, pseudos, attrEqualityMods, ruleNestingOperators,
   getIdent = function() {
     var result = '';
     chr = str.charAt(pos);
-    var replacement;
     while (pos < l) {
       if (isIdent(chr)) {
         result += chr;
       } else if (chr === '\\') {
         pos++;
+        if (pos >= l) {
+          throw Error('Expected symbol but end of file reached.');
+        }
         chr = str.charAt(pos);
         if (identSpecialChars[chr]) {
           result += chr;
-        } else if (replacement = identReplacements[chr]) {
-          result += replacement;
         } else if (isHex(chr)) {
           var hex = chr;
           pos++;
@@ -337,44 +319,7 @@ function ParseContext(str, pos, pseudos, attrEqualityMods, ruleNestingOperators,
         (rule.classNames = rule.classNames || []).push(getIdent());
       } else if (chr === '#') {
         pos++;
-        chr = str.charAt(pos);
-        var id = '';
-        while (chr === '\\' || isIdent(chr)) {
-          if (chr === '\\') {
-            pos++;
-            if (pos >= l) {
-              throw Error('Expected symbol but end of file reached.');
-            }
-            var escapedCharacter = str.charAt(pos);
-            while (pos < l && escapedCharacter === '0') {
-              pos++;
-              escapedCharacter = str.charAt(pos);
-            }
-            if (escapedCharacter === '3') {
-              pos++;
-              if (pos < l) {
-                id += str.charAt(pos);
-                pos++;
-                var followingCharacter = str.charAt(pos);
-                if (followingCharacter === ' ') {
-                  pos++;
-                  if (pos < l) {
-                    id += str.charAt(pos);
-                  }
-                } else {
-                  id += followingCharacter;
-                }
-              }
-            } else {
-              id += escapedCharacter;
-            }
-          } else {
-            id += chr;
-          }
-          pos++;
-          chr = str.charAt(pos);
-        }
-        (rule = rule || {}).id = id;
+        (rule = rule || {}).id = getIdent();
       } else if (chr === '[') {
         pos++;
         skipWhitespace();
@@ -505,36 +450,35 @@ CssSelectorParser.prototype.escapeIdentifier = function(s) {
   var result = '';
   var i = 0;
   var len = s.length;
-  var replacement, charCode;
   while (i < len) {
     var chr = s.charAt(i);
     if (identSpecialChars[chr]) {
       result += '\\' + chr;
-    } else if (replacement = identReplacementsRev[chr]) {
-      result += replacement;
-    } else if ((charCode = chr.charCodeAt(0)) && (charCode < 32 || charCode > 126)) {
-      if ((charCode & 0xF800) === 0xD800) {
-        var extraCharCode = s.charCodeAt(i++);
-        if ((charCode & 0xFC00) !== 0xD800 || (extraCharCode & 0xFC00) !== 0xDC00) {
-          throw Error('UCS-2(decode): illegal sequence');
-        }
-        charCode = ((charCode & 0x3FF) << 10) + (extraCharCode & 0x3FF) + 0x10000;
-      }
-      result += '\\' + charCode.toString(16) + ' ';
     } else {
-      result += chr;
+      if (
+          !(
+              chr === '_' || chr === '-' ||
+              (chr >= 'A' && chr <= 'Z') ||
+              (chr >= 'a' && chr <= 'z') ||
+              (i !== 0 && chr >= '0' && chr <= '9')
+          )
+      ) {
+        var charCode = chr.charCodeAt(0);
+        if ((charCode & 0xF800) === 0xD800) {
+          var extraCharCode = s.charCodeAt(i++);
+          if ((charCode & 0xFC00) !== 0xD800 || (extraCharCode & 0xFC00) !== 0xDC00) {
+            throw Error('UCS-2(decode): illegal sequence');
+          }
+          charCode = ((charCode & 0x3FF) << 10) + (extraCharCode & 0x3FF) + 0x10000;
+        }
+        result += '\\' + charCode.toString(16) + ' ';
+      } else {
+        result += chr;
+      }
     }
     i++;
   }
   return result;
-};
-
-CssSelectorParser.prototype.escapeId = function(s) {
-  var first = s[0];
-  if (isDecimal(first)) {
-    return "\\3" + (this.escapeIdentifier(first)) + " " + (this.escapeIdentifier(s.slice(1)));
-  }
-  return this.escapeIdentifier(s);
 };
 
 CssSelectorParser.prototype.escapeStr = function(s) {
@@ -558,7 +502,7 @@ CssSelectorParser.prototype.escapeStr = function(s) {
 };
 
 CssSelectorParser.prototype.render = function(path) {
-  return this._renderEntity(path);
+  return this._renderEntity(path).trim();
 };
 
 CssSelectorParser.prototype._renderEntity = function(entity) {
@@ -589,7 +533,7 @@ CssSelectorParser.prototype._renderEntity = function(entity) {
         }
       }
       if (entity.id) {
-        res += "#" + (this.escapeId(entity.id));
+        res += "#" + this.escapeIdentifier(entity.id);
       }
       if (entity.classNames) {
         res += entity.classNames.map(function(cn) {

--- a/test/test.js
+++ b/test/test.js
@@ -165,13 +165,25 @@ assertError('Expected symbol but end of file reached.', function() {
     return parser.parse('#iframe_\\');
 });
 
-assertEquals('tag\\n\\\\name\\.\\[', parser.render(parser.parse('tag\\n\\\\name\\.\\[')));
+assertEquals('tag\\/name', parser.render(parser.parse('tag\\/name')));
 
-assertEquals('.cls\\n\\\\name\\.\\[', parser.render(parser.parse('.cls\\n\\\\name\\.\\[')));
+assertEquals('.class\\/name', parser.render(parser.parse('.class\\/name')));
 
-assertEquals('[attr\\n\\\\name\\.\\[="1"]', parser.render(parser.parse('[attr\\n\\\\name\\.\\[=1]')));
+assertEquals('#id\\/name', parser.render(parser.parse('#id\\/name')));
 
-assertEquals(':pseudo\\n\\\\name\\.\\[\\(("123")', parser.render(parser.parse(':pseudo\\n\\\\name\\.\\[\\((123)')));
+assertEquals('.\\30 wow', parser.render(parser.parse('.\\30 wow')));
+
+assertEquals('.\\30 wow', parser.render(parser.parse('.\\30wow')));
+
+assertEquals('.\\20 wow', parser.render(parser.parse('.\\20wow')));
+
+assertEquals('tagn\\\\name\\.\\[', parser.render(parser.parse('tag\\n\\\\name\\.\\[')));
+
+assertEquals('.clsn\\\\name\\.\\[', parser.render(parser.parse('.cls\\n\\\\name\\.\\[')));
+
+assertEquals('[attrn\\\\name\\.\\[="1"]', parser.render(parser.parse('[attr\\n\\\\name\\.\\[=1]')));
+
+assertEquals(':pseudon\\\\name\\.\\[\\(("123")', parser.render(parser.parse(':pseudo\\n\\\\name\\.\\[\\((123)')));
 
 assertEquals('[attr="val\\nval"]', parser.render(parser.parse('[attr="val\nval"]')));
 
@@ -231,13 +243,13 @@ assertEquals(
     parser.render(parser.parse('#google_ads_iframe_\\/100500\\/Pewpew_0'))
 );
 
-assertEquals('#\\31 23', parser.render(parser.parse('#\\3123')));
+assertEquals('#\\3123', parser.render(parser.parse('#\\3123')));
 
 assertEquals('#\\31 23', parser.render(parser.parse('#\\31 23')));
 
 assertEquals('#\\31 23', parser.render(parser.parse('#\\00031 23')));
 
-assertEquals('#\\31 23', parser.render(parser.parse('#\\0003123')));
+assertEquals('#\\3123', parser.render(parser.parse('#\\0003123')));
 
-assertEquals('#\\34 123', parser.render(parser.parse('#\\0004123')));
+assertEquals('#\\4123', parser.render(parser.parse('#\\0004123')));
 


### PR DESCRIPTION
What was fixed:

* Hex numbers here not parsed properly (only two digits were parsed, though in browsers all digits are processed).
* Class names rendering didn't always escape characters properly.
* Illegal escaping in identifiers was removed (`\n, \r, etc`).
* Some tests for `/`. It was actually working properly @anselmh.

cc @azproduction,